### PR TITLE
Fix #95 BindingInflate ignores container

### DIFF
--- a/src/Templates/MvxNative/NavigationMenu/src/MvxNative.Droid/Views/!Base/BaseFragment.cs
+++ b/src/Templates/MvxNative/NavigationMenu/src/MvxNative.Droid/Views/!Base/BaseFragment.cs
@@ -24,7 +24,7 @@ namespace MvxNative.Droid.Views
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            return this.BindingInflate(FragmentLayoutId, null);
+            return this.BindingInflate(FragmentLayoutId, container, false);
         }
     }
 }

--- a/src/Templates/MvxNative/SingleView/src/MvxNative.Droid/Views/!Base/BaseFragment.cs
+++ b/src/Templates/MvxNative/SingleView/src/MvxNative.Droid/Views/!Base/BaseFragment.cs
@@ -24,7 +24,7 @@ namespace MvxNative.Droid.Views
         {
             base.OnCreateView(inflater, container, savedInstanceState);
 
-            return this.BindingInflate(FragmentLayoutId, null);
+            return this.BindingInflate(FragmentLayoutId, container, false);
         }
     }
 }


### PR DESCRIPTION
Not using the container can lead to misbehaviors when inflated child view does not get the LayoutParameters from parent.

Fixes #95 