### PR TITLE
Respect safe area on iPhone X

### DIFF
--- a/src/Templates/MvxNative/NavigationMenu/src/MvxNative.iOS/Views/Menu/MenuView.cs
+++ b/src/Templates/MvxNative/NavigationMenu/src/MvxNative.iOS/Views/Menu/MenuView.cs
@@ -77,9 +77,13 @@ namespace MvxNative.iOS.Views.Menu
 
         protected override void LayoutView()
         {
+            NSObject topGuide = UIDevice.CurrentDevice.CheckSystemVersion(11, 0) ? 
+                View.SafeAreaLayoutGuide : View.LayoutMarginsGuide;
+            
             View.AddConstraints(new FluentLayout[]
             {
-                _menuHome.AtTopOf(View, 25f),
+                _menuHome.Top().EqualTo().TopOf(topGuide).Plus(25f),
+                _menuHome.AtLeftOf(View, 10f),
                 _menuHome.AtLeftOf(View, 10f),
                 _menuHome.ToRightOf(View),
 


### PR DESCRIPTION
Home item in menu was in the status bar area and hard to click on iPhone X. Using SafeAreaLayoutGuide to move it down.