### PR TITLE
Bump Android MvxNative templates to use support library v27.0.2.1

### DIFF
--- a/src/Templates/MvxNative/NavigationMenu/src/MvxNative.Droid/MvxNative.Droid.csproj
+++ b/src/Templates/MvxNative/NavigationMenu/src/MvxNative.Droid/MvxNative.Droid.csproj
@@ -88,6 +88,9 @@
     <PackageReference Include="Xamarin.Android.Support.Constraint.Layout">
       <Version>1.1.2</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Design">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProguardConfiguration Include="proguard.cfg" />

--- a/src/Templates/MvxNative/SingleView/src/MvxNative.Droid/MvxNative.Droid.csproj
+++ b/src/Templates/MvxNative/SingleView/src/MvxNative.Droid/MvxNative.Droid.csproj
@@ -85,6 +85,9 @@
     <PackageReference Include="Xamarin.Android.Support.Constraint.Layout">
       <Version>1.1.2</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.Design">
+      <Version>27.0.2.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProguardConfiguration Include="proguard.cfg" />


### PR DESCRIPTION
Fix MvxNative Android Crash on devices 19 and lower
