### PR TITLE
stuff that didn’t compile with mvxforms

### DIFF
--- a/src/Templates/MvxForms/NavigationMenu/src/MvxFormsTemp.UI/App.xaml
+++ b/src/Templates/MvxForms/NavigationMenu/src/MvxFormsTemp.UI/App.xaml
@@ -3,7 +3,7 @@
     x:Class="MvxFormsTemp.UI.App"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:d="clr-namespace:MvvmCross.Forms.Platform;assembly=MvvmCross.Forms"
+    xmlns:d="clr-namespace:MvvmCross.Forms;assembly=MvvmCross.Forms"
     xmlns:resources="clr-namespace:MvxFormsTemp.UI.Resources">
     <Application.Resources>
 

--- a/src/Templates/MvxForms/NavigationMenu/src/MvxFormsTemp.UI/Pages/HomePage.xaml
+++ b/src/Templates/MvxForms/NavigationMenu/src/MvxFormsTemp.UI/Pages/HomePage.xaml
@@ -6,7 +6,7 @@
     xmlns:mvx="clr-namespace:MvvmCross.Forms.Bindings;assembly=MvvmCross.Forms"
     xmlns:local="clr-namespace:MvxFormsTemp.UI.Pages"
     x:Class="MvxFormsTemp.UI.Pages.HomePage"
-    xmlns:viewModels="clr-namespace:MvxFormsTemp.Core.ViewModels.Home;assembly=MvxForms.Core"
+    xmlns:viewModels="clr-namespace:MvxFormsTemp.Core.ViewModels.Home;assembly=MvxFormsTemp.Core"
                       Title="Main page">
     <ContentPage.Content>
         <StackLayout>

--- a/src/Templates/MvxForms/SingleView/src/MvxFormsTemp.UI/App.xaml
+++ b/src/Templates/MvxForms/SingleView/src/MvxFormsTemp.UI/App.xaml
@@ -3,7 +3,7 @@
     x:Class="MvxFormsTemp.UI.App"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:d="clr-namespace:MvvmCross.Forms.Platform;assembly=MvvmCross.Forms"
+    xmlns:d="clr-namespace:MvvmCross.Forms;assembly=MvvmCross.Forms"
     xmlns:resources="clr-namespace:MvxFormsTemp.UI.Resources">
     <Application.Resources>
 

--- a/src/Templates/MvxForms/SingleView/src/MvxFormsTemp.UI/Pages/HomePage.xaml
+++ b/src/Templates/MvxForms/SingleView/src/MvxFormsTemp.UI/Pages/HomePage.xaml
@@ -6,7 +6,7 @@
     xmlns:mvx="clr-namespace:MvvmCross.Forms.Bindings;assembly=MvvmCross.Forms"
     xmlns:local="clr-namespace:MvxFormsTemp.UI.Pages"
     x:Class="MvxFormsTemp.UI.Pages.HomePage"
-    xmlns:viewModels="clr-namespace:MvxFormsTemp.Core.ViewModels.Home;assembly=MvxForms.Core"
+    xmlns:viewModels="clr-namespace:MvxFormsTemp.Core.ViewModels.Home;assembly=MvxFormsTemp.Core"
                       Title="Main page">
     <ContentPage.Content>
         <StackLayout>


### PR DESCRIPTION
this is stuff I had to manually change for the mvxforms template to work. I don't know much about scaffolding, so I'm guessing here that `MvxFormsTemp` gets automatically replaced ? I'm guessing it's because of ```dotnet new mvxnative --solution-name xxx``` but it was mandatory.