### PR TITLE
Add constructor references for various MvvmCross types to LinkerPleaseInclude files

### DIFF
--- a/src/Templates/MvxForms/Blank/src/MvxFormsTemp.iOS/Linker/LinkerPleaseInclude.cs
+++ b/src/Templates/MvxForms/Blank/src/MvxFormsTemp.iOS/Linker/LinkerPleaseInclude.cs
@@ -4,6 +4,8 @@ using System.ComponentModel;
 using System.Windows.Input;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
+using MvvmCross.Commands;
+using MvvmCross.Core;
 using MvvmCross.IoC;
 using MvvmCross.Navigation;
 using MvvmCross.Platforms.Ios.Views;
@@ -143,6 +145,41 @@ namespace MvxFormsTemp.iOS.Linker
             Console.ForegroundColor = ConsoleColor.White;
             Console.ForegroundColor = ConsoleColor.Gray;
             Console.ForegroundColor = ConsoleColor.DarkGray;
+        }
+
+        public void Include(MvxSettings settings)
+        {
+            _ = new MvxSettings();
+        }
+
+        public void Include(MvxStringToTypeParser parser)
+        {
+            _ = new MvxStringToTypeParser();
+        }
+
+        public void Include(MvxViewModelLoader loader)
+        {
+            _ = new MvxViewModelLoader(null);
+        }
+
+        public void Include(MvxViewModelViewLookupBuilder builder)
+        {
+            _ = new MvxViewModelViewLookupBuilder();
+        }
+
+        public void Include(MvxCommandCollectionBuilder builder)
+        {
+            _ = new MvxCommandCollectionBuilder();
+        }
+
+        public void Include(MvxStringDictionaryNavigationSerializer serializer)
+        {
+            _ = new MvxStringDictionaryNavigationSerializer();
+        }
+
+        public void Include(MvxChildViewModelCache cache)
+        {
+            _ = new MvxChildViewModelCache();
         }
     }
 }

--- a/src/Templates/MvxForms/NavigationMenu/src/MvxFormsTemp.iOS/Linker/LinkerPleaseInclude.cs
+++ b/src/Templates/MvxForms/NavigationMenu/src/MvxFormsTemp.iOS/Linker/LinkerPleaseInclude.cs
@@ -4,6 +4,8 @@ using System.ComponentModel;
 using System.Windows.Input;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
+using MvvmCross.Commands;
+using MvvmCross.Core;
 using MvvmCross.IoC;
 using MvvmCross.Navigation;
 using MvvmCross.Platforms.Ios.Views;
@@ -143,6 +145,41 @@ namespace MvxFormsTemp.iOS.Linker
             Console.ForegroundColor = ConsoleColor.White;
             Console.ForegroundColor = ConsoleColor.Gray;
             Console.ForegroundColor = ConsoleColor.DarkGray;
+        }
+
+        public void Include(MvxSettings settings)
+        {
+            _ = new MvxSettings();
+        }
+
+        public void Include(MvxStringToTypeParser parser)
+        {
+            _ = new MvxStringToTypeParser();
+        }
+
+        public void Include(MvxViewModelLoader loader)
+        {
+            _ = new MvxViewModelLoader(null);
+        }
+
+        public void Include(MvxViewModelViewLookupBuilder builder)
+        {
+            _ = new MvxViewModelViewLookupBuilder();
+        }
+
+        public void Include(MvxCommandCollectionBuilder builder)
+        {
+            _ = new MvxCommandCollectionBuilder();
+        }
+
+        public void Include(MvxStringDictionaryNavigationSerializer serializer)
+        {
+            _ = new MvxStringDictionaryNavigationSerializer();
+        }
+
+        public void Include(MvxChildViewModelCache cache)
+        {
+            _ = new MvxChildViewModelCache();
         }
     }
 }

--- a/src/Templates/MvxForms/SingleView/src/MvxFormsTemp.iOS/Linker/LinkerPleaseInclude.cs
+++ b/src/Templates/MvxForms/SingleView/src/MvxFormsTemp.iOS/Linker/LinkerPleaseInclude.cs
@@ -4,6 +4,8 @@ using System.ComponentModel;
 using System.Windows.Input;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
+using MvvmCross.Commands;
+using MvvmCross.Core;
 using MvvmCross.IoC;
 using MvvmCross.Navigation;
 using MvvmCross.Platforms.Ios.Views;
@@ -143,6 +145,41 @@ namespace MvxFormsTemp.iOS.Linker
             Console.ForegroundColor = ConsoleColor.White;
             Console.ForegroundColor = ConsoleColor.Gray;
             Console.ForegroundColor = ConsoleColor.DarkGray;
+        }
+
+        public void Include(MvxSettings settings)
+        {
+            _ = new MvxSettings();
+        }
+
+        public void Include(MvxStringToTypeParser parser)
+        {
+            _ = new MvxStringToTypeParser();
+        }
+
+        public void Include(MvxViewModelLoader loader)
+        {
+            _ = new MvxViewModelLoader(null);
+        }
+
+        public void Include(MvxViewModelViewLookupBuilder builder)
+        {
+            _ = new MvxViewModelViewLookupBuilder();
+        }
+
+        public void Include(MvxCommandCollectionBuilder builder)
+        {
+            _ = new MvxCommandCollectionBuilder();
+        }
+
+        public void Include(MvxStringDictionaryNavigationSerializer serializer)
+        {
+            _ = new MvxStringDictionaryNavigationSerializer();
+        }
+
+        public void Include(MvxChildViewModelCache cache)
+        {
+            _ = new MvxChildViewModelCache();
         }
     }
 }

--- a/src/Templates/MvxNative/Blank/src/MvxNative.iOS/Linker/LinkerPleaseInclude.cs
+++ b/src/Templates/MvxNative/Blank/src/MvxNative.iOS/Linker/LinkerPleaseInclude.cs
@@ -4,6 +4,8 @@ using System.ComponentModel;
 using System.Windows.Input;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
+using MvvmCross.Commands;
+using MvvmCross.Core;
 using MvvmCross.IoC;
 using MvvmCross.Navigation;
 using MvvmCross.Platforms.Ios.Views;
@@ -143,6 +145,41 @@ namespace MvxNative.iOS.Linker
             Console.ForegroundColor = ConsoleColor.White;
             Console.ForegroundColor = ConsoleColor.Gray;
             Console.ForegroundColor = ConsoleColor.DarkGray;
+        }
+
+        public void Include(MvxSettings settings)
+        {
+            _ = new MvxSettings();
+        }
+
+        public void Include(MvxStringToTypeParser parser)
+        {
+            _ = new MvxStringToTypeParser();
+        }
+
+        public void Include(MvxViewModelLoader loader)
+        {
+            _ = new MvxViewModelLoader(null);
+        }
+
+        public void Include(MvxViewModelViewLookupBuilder builder)
+        {
+            _ = new MvxViewModelViewLookupBuilder();
+        }
+
+        public void Include(MvxCommandCollectionBuilder builder)
+        {
+            _ = new MvxCommandCollectionBuilder();
+        }
+
+        public void Include(MvxStringDictionaryNavigationSerializer serializer)
+        {
+            _ = new MvxStringDictionaryNavigationSerializer();
+        }
+
+        public void Include(MvxChildViewModelCache cache)
+        {
+            _ = new MvxChildViewModelCache();
         }
     }
 }

--- a/src/Templates/MvxNative/NavigationMenu/src/MvxNative.iOS/Linker/LinkerPleaseInclude.cs
+++ b/src/Templates/MvxNative/NavigationMenu/src/MvxNative.iOS/Linker/LinkerPleaseInclude.cs
@@ -4,6 +4,8 @@ using System.ComponentModel;
 using System.Windows.Input;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
+using MvvmCross.Commands;
+using MvvmCross.Core;
 using MvvmCross.IoC;
 using MvvmCross.Navigation;
 using MvvmCross.Platforms.Ios.Views;
@@ -143,6 +145,41 @@ namespace MvxNative.iOS.Linker
             Console.ForegroundColor = ConsoleColor.White;
             Console.ForegroundColor = ConsoleColor.Gray;
             Console.ForegroundColor = ConsoleColor.DarkGray;
+        }
+
+        public void Include(MvxSettings settings)
+        {
+            _ = new MvxSettings();
+        }
+
+        public void Include(MvxStringToTypeParser parser)
+        {
+            _ = new MvxStringToTypeParser();
+        }
+
+        public void Include(MvxViewModelLoader loader)
+        {
+            _ = new MvxViewModelLoader(null);
+        }
+
+        public void Include(MvxViewModelViewLookupBuilder builder)
+        {
+            _ = new MvxViewModelViewLookupBuilder();
+        }
+
+        public void Include(MvxCommandCollectionBuilder builder)
+        {
+            _ = new MvxCommandCollectionBuilder();
+        }
+
+        public void Include(MvxStringDictionaryNavigationSerializer serializer)
+        {
+            _ = new MvxStringDictionaryNavigationSerializer();
+        }
+
+        public void Include(MvxChildViewModelCache cache)
+        {
+            _ = new MvxChildViewModelCache();
         }
     }
 }

--- a/src/Templates/MvxNative/SingleView/src/MvxNative.iOS/Linker/LinkerPleaseInclude.cs
+++ b/src/Templates/MvxNative/SingleView/src/MvxNative.iOS/Linker/LinkerPleaseInclude.cs
@@ -4,6 +4,8 @@ using System.ComponentModel;
 using System.Windows.Input;
 using Foundation;
 using MvvmCross.Binding.BindingContext;
+using MvvmCross.Commands;
+using MvvmCross.Core;
 using MvvmCross.IoC;
 using MvvmCross.Navigation;
 using MvvmCross.Platforms.Ios.Views;
@@ -143,6 +145,41 @@ namespace MvxNative.iOS.Linker
             Console.ForegroundColor = ConsoleColor.White;
             Console.ForegroundColor = ConsoleColor.Gray;
             Console.ForegroundColor = ConsoleColor.DarkGray;
+        }
+
+        public void Include(MvxSettings settings)
+        {
+            _ = new MvxSettings();
+        }
+
+        public void Include(MvxStringToTypeParser parser)
+        {
+            _ = new MvxStringToTypeParser();
+        }
+
+        public void Include(MvxViewModelLoader loader)
+        {
+            _ = new MvxViewModelLoader(null);
+        }
+
+        public void Include(MvxViewModelViewLookupBuilder builder)
+        {
+            _ = new MvxViewModelViewLookupBuilder();
+        }
+
+        public void Include(MvxCommandCollectionBuilder builder)
+        {
+            _ = new MvxCommandCollectionBuilder();
+        }
+
+        public void Include(MvxStringDictionaryNavigationSerializer serializer)
+        {
+            _ = new MvxStringDictionaryNavigationSerializer();
+        }
+
+        public void Include(MvxChildViewModelCache cache)
+        {
+            _ = new MvxChildViewModelCache();
         }
     }
 }


### PR DESCRIPTION
Add constructor references for various MvvmCross types to LinkerPleaseInclude files.

Resolution for issue #687.